### PR TITLE
Adding missing Permission and Bumping actions/checkout to v4

### DIFF
--- a/.github/workflows/create-pairs.yml
+++ b/.github/workflows/create-pairs.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read  # allows checkout to read repo
       issues: write   # allows reading and writing to issues
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
       - name: Create Issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -6,6 +6,9 @@ jobs:
   initialize_repo:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    permissions: 
+      issues: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0


### PR DESCRIPTION
**Changes:**

- Adds permission for `issues` as the workflow failed creating an issue.
- Adds permission `content: read` to workflow as the checkout action failed when the repo is private.
- Bumps version of `actions/checkout` to `v4`